### PR TITLE
FIX channel can be seen even if read false but not managed

### DIFF
--- a/server/commands/focus.command.js
+++ b/server/commands/focus.command.js
@@ -71,7 +71,7 @@ function setRole(user, name_role, message, date, dry) {
 function setPermissionFocus(message) {
   message.guild.channels.forEach((chan) => {
     message.member.setVoiceChannel(null);
-    if (chan.name !== 'focus') {
+    if (chan.name !== 'focus' && chan.manageable) {
       chan.overwritePermissions(message.author, { VIEW_CHANNEL: false });
     }
   });

--- a/server/commands/unfocus.command.js
+++ b/server/commands/unfocus.command.js
@@ -99,7 +99,7 @@ function h_n_m(minutes) {
 
 function setPermissionUnfocus(message, member) {
   message.guild.channels.forEach((chan) => {
-    if (chan.name !== 'focus') {
+    if (chan.name !== 'focus' && chan.manageable) {
       chan.overwritePermissions(member, { VIEW_CHANNEL: null });
     }
   });


### PR DESCRIPTION
bot was trying to assign permissions on the channel without right to do so