### PR TITLE
FIX fixing position again. Cache problem

### DIFF
--- a/server/commands/userinfo.command.js
+++ b/server/commands/userinfo.command.js
@@ -40,13 +40,14 @@ function buildEmbedMember(member) {
   }
   embed.addField(
     'Joined Position',
-    member.guild.members
-      .clone()
-      .sort(
-        (memberA, memberB) => memberA.joinedTimestamp - memberB.joinedTimestamp
-      )
-      .keyArray()
-      .indexOf(member.id) + 1,
+    Array.from(
+      member.guild.members
+        .sort(
+          (memberA, memberB) =>
+            memberA.joinedTimestamp - memberB.joinedTimestamp
+        )
+        .keys()
+    ).indexOf(member.id) + 1,
     true
   );
   embed.addField('Presence', getStatusPresence(member.presence.status), true);


### PR DESCRIPTION
from discord.js.org
> Creates an ordered array of the keys of this collection, and caches it internally. The array will only be reconstructed if an item is added to or removed from the collection, or if you change the length of the array itself. If you don't want this caching behavior, use [...collection.keys()] or Array.from(collection.keys()) instead.