### PR TITLE
Bug fixes for +create, +adapted, extra info for +status

### DIFF
--- a/server/commands/adapted.command.js
+++ b/server/commands/adapted.command.js
@@ -69,7 +69,7 @@ async function adapt(message, args, dry) {
           scheduleIdentifier
         ));
         if (!is_schedule) {
-          message.channel.sen('Error in the database. Contact admins.');
+          message.channel.send('Error in the database. Contact admins.');
           throw new CustomError(
             'DataError',
             `Incorrect schedule stored in databasse: ${scheduleIdentifier}`
@@ -123,12 +123,25 @@ async function adaptOne(member, userDB, schedule, changeDB, message, dry) {
   let rolesToAdd = [];
   let rolesToDelete = [];
   if (changeDB) {
+    const adapted = true;
+    const userUpdate = buildUserInstance(member.user, message, schedule);
+    const result = await saveUserSchedule(
+      message,
+      userUpdate,
+      member.user,
+      dry,
+      adapted
+    );
+    const msg = `${member.user.tag} is now adapted`;
+    console.log('INFO:  ', msg);
+    console.log('Save User Schedule result:', result);
+    await message.channel.send(msg);
     rolesToAdd.push(findArrayMember(member.guild.roles, 'Currently Adapted'));
   }
   rolesToDelete.push(
-    findArrayMember(member.guild.roles, 'Attempted-' + schedule)
+    findArrayMember(member.guild.roles, 'Attempted-' + schedule.split("-")[0])
   );
-  rolesToAdd.push(findArrayMember(member.guild.roles, 'Adapted-' + schedule));
+  rolesToAdd.push(findArrayMember(member.guild.roles, 'Adapted-' + schedule.split("-")[0]));
   let rolesToAddMsg = rolesToAdd.map((r) => r[0]).join(', ');
   let rolesToDeleteMsg = rolesToDelete.map((r) => r[0]).join(', ');
   if (
@@ -168,21 +181,7 @@ async function adaptOne(member, userDB, schedule, changeDB, message, dry) {
         throw e;
       }
     }
-    if (changeDB) {
-      const adapted = true;
-      const userUpdate = buildUserInstance(member.user, message, schedule);
-      const result = await saveUserSchedule(
-        message,
-        userUpdate,
-        member.user,
-        dry,
-        adapted
-      );
-      const msg = `${member.user.tag} is now adapted`;
-      console.log('INFO:  ', msg);
-      console.log('Save User Schedule result:', result);
-      await message.channel.send(msg);
-    }
+
   }
 }
 

--- a/server/commands/create.command.js
+++ b/server/commands/create.command.js
@@ -28,13 +28,16 @@ async function create(args, message, dry) {
   try {
     args.forEach((arg)=>{
       let times = arg.split('-');
-      let hm1 = times[0].split(':');
-      let hm2 = times[1].split(':');
-      s = parseInt(hm1[0])*60 + parseInt(hm1[1]);
-      e = parseInt(hm2[0])*60 + parseInt(hm2[1]);
+      s = parseTime(times[0]);
+      e = parseTime(times[1]);
+      if (s > 1440 || e > 1440){
+        message.channel.send("You're dumb.");
+        throw new Error();
+      }
+
       timeelems.push({
-	start: s, 
-	end: e, 
+	start: s,
+	end: e,
 	id: i++,
 	lane: 0,
 	text: "",
@@ -66,4 +69,27 @@ async function create(args, message, dry) {
   nurl = await createChart(data);
   emb = await getOrGenImg(nurl,message,dry);
   if(!dry){message.channel.send(emb);}
+}
+function parseTime(s) {
+  let hours;
+  let hm = null;
+
+  if (s.includes(":")){
+    hm = s.split(":");
+  }
+  else if (s.length == 4){
+    hm = [s.slice(0,2), s.slice(2,4)];
+  }
+  else if (s.length == 3){
+    hm = [s.slice(0,1), s.slice(1,3)];
+  }
+
+  if (hm){
+    hours = parseInt(hm[0]);
+    hours += parseInt(hm[1]) / 60;
+  }
+  else{
+    hours = parseInt(s);
+  }
+  return 60 * hours;
 }

--- a/server/commands/create.command.js
+++ b/server/commands/create.command.js
@@ -31,7 +31,7 @@ async function create(args, message, dry) {
       s = parseTime(times[0]);
       e = parseTime(times[1]);
       if (s > 1440 || e > 1440){
-        message.channel.send("You're dumb.");
+        message.channel.send("Please don't try to break the bot. It's hard work.");
         throw new Error();
       }
 

--- a/server/commands/getstatus.command.js
+++ b/server/commands/getstatus.command.js
@@ -88,7 +88,7 @@ async function get(message, args, dry) {
       message.channel.send(msg);
   }
   else {
-    message.channel.send("Error: User " + bold(member.value.displayName) + " has not set a timezone.")
+    message.channel.send("Error: User " + bold(member.value.displayName) + " has not set a timezone. You can set a timezone with `+settz [timezone]`")
   }
 }
 


### PR DESCRIPTION
- `+create` now can accept times with only hours in some parts, such as `+create 3-8`.
- `+create` no longer accepts hours greater than 24, because this causes errors for logs and status, and will say "You're dumb" if it detects any attempt to do so.
- `+adapted` should now work for schedules with modifiers, and also even if there is no corresponding role in the discord, it should still record the adapted state.
- `+status` now has a reminder about how to set a timezone.
