### PR TITLE
fix(build): avoid downloading too recent devdependencies on prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:carbon
+ENV NODE_ENV=production
 WORKDIR /usr/src/napgodjs-build
+
 COPY package.json /usr/src/napgodjs-build
 COPY package-lock.json /usr/src/napgodjs-build
 RUN npm install


### PR DESCRIPTION
Old version of node (carbon) having issues with too recent DevDependencies.