### PR TITLE
Add support for 6 chars in napcharts

### DIFF
--- a/server/commands/set.backend.js
+++ b/server/commands/set.backend.js
@@ -7,7 +7,7 @@ const schedules = require("./schedules").schedules;
 const modifiers = require("./schedules").modifiers;
 const { getNapchart } = require('./napchart.js');
 
-const napchartPathRegex = /^\w{5}$/
+const napchartPathRegex = /^\w{5,6}$/
 
 
 module.exports = {


### PR DESCRIPTION
This super small fix makes sure the bot works with 5 chars and 6 chars.